### PR TITLE
Add glass-ui component library

### DIFF
--- a/glass-ui/README.md
+++ b/glass-ui/README.md
@@ -1,0 +1,47 @@
+# @glass/ui
+
+Reusable React component library built on top of [liquid-glass-react](https://github.com/rdev/liquid-glass-react). It provides common UI primitives such as buttons, cards, inputs and modals with a frosted glassmorphism effect.
+
+## Installation
+
+```bash
+npm install @glass/ui liquid-glass-react
+```
+
+`@glass/ui` requires `react`, `react-dom` and `liquid-glass-react` as peer dependencies.
+
+## Usage
+
+```tsx
+import { Button, Card, Input, Modal } from '@glass/ui'
+
+function Example() {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>Open Modal</Button>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <Card>
+          <h2 className="text-xl font-semibold mb-2">Hello Glass!</h2>
+          <Input placeholder="Type here" />
+        </Card>
+      </Modal>
+    </div>
+  )
+}
+```
+
+Each component accepts all the props from `liquid-glass-react` like `blurAmount`, `saturation`, `cornerRadius` etc., allowing full control over the glass effect.
+
+## Components
+
+- **Button** – clickable button.
+- **Card** – basic container for content.
+- **Input** – text input field.
+- **Modal** – centered dialog overlay.
+
+## Development
+
+The package ships with ESM and CommonJS builds. Run `npm run build` to generate the `dist` folder.
+
+

--- a/glass-ui/package.json
+++ b/glass-ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@glass/ui",
+  "version": "0.1.0",
+  "description": "UI components with liquid-glass-react",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.esm.js --external:react --external:react-dom --external:liquid-glass-react",
+    "build:cjs": "esbuild src/index.ts --bundle --format=cjs --outfile=dist/index.js --external:react --external:react-dom --external:liquid-glass-react",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18",
+    "liquid-glass-react": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "esbuild": "^0.19.0",
+    "typescript": "^5.0.0"
+  },
+  "keywords": ["react", "ui", "glass", "component"],
+  "license": "MIT"
+}

--- a/glass-ui/src/components/Button.tsx
+++ b/glass-ui/src/components/Button.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import LiquidGlass from 'liquid-glass-react'
+import { GlassProps } from '../types'
+import { cn } from '../utils'
+
+/**
+ * Button component rendered with a liquid glass background.
+ */
+export interface ButtonProps extends GlassProps, React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  const {
+    children,
+    className,
+    style,
+    padding = '8px 16px',
+    displacementScale,
+    blurAmount,
+    saturation,
+    aberrationIntensity,
+    elasticity,
+    cornerRadius,
+    overLight,
+    mode,
+    mouseContainer,
+    ...buttonProps
+  } = props
+
+  return (
+    <LiquidGlass
+      displacementScale={displacementScale}
+      blurAmount={blurAmount}
+      saturation={saturation}
+      aberrationIntensity={aberrationIntensity}
+      elasticity={elasticity}
+      cornerRadius={cornerRadius}
+      overLight={overLight}
+      mode={mode}
+      mouseContainer={mouseContainer}
+      padding={padding}
+      className={cn('inline-block cursor-pointer select-none', className)}
+      style={style}
+    >
+      <button ref={ref} className="bg-transparent border-none outline-none p-0 m-0 w-full h-full" {...buttonProps}>
+        {children}
+      </button>
+    </LiquidGlass>
+  )
+})
+
+Button.displayName = 'Button'
+

--- a/glass-ui/src/components/Card.tsx
+++ b/glass-ui/src/components/Card.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import LiquidGlass from 'liquid-glass-react'
+import { GlassProps } from '../types'
+import { cn } from '../utils'
+
+/**
+ * Card component with liquid glass styling.
+ */
+export interface CardProps extends GlassProps, React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
+  const {
+    children,
+    className,
+    style,
+    padding = '24px 32px',
+    displacementScale,
+    blurAmount,
+    saturation,
+    aberrationIntensity,
+    elasticity,
+    cornerRadius,
+    overLight,
+    mode,
+    mouseContainer,
+    ...divProps
+  } = props
+
+  return (
+    <LiquidGlass
+      displacementScale={displacementScale}
+      blurAmount={blurAmount}
+      saturation={saturation}
+      aberrationIntensity={aberrationIntensity}
+      elasticity={elasticity}
+      cornerRadius={cornerRadius}
+      overLight={overLight}
+      mode={mode}
+      mouseContainer={mouseContainer}
+      padding={padding}
+      className={cn('block', className)}
+      style={style}
+    >
+      <div ref={ref} {...divProps}>
+        {children}
+      </div>
+    </LiquidGlass>
+  )
+})
+
+Card.displayName = 'Card'
+

--- a/glass-ui/src/components/Input.tsx
+++ b/glass-ui/src/components/Input.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import LiquidGlass from 'liquid-glass-react'
+import { GlassProps } from '../types'
+import { cn } from '../utils'
+
+/**
+ * Input component wrapped with liquid glass background.
+ */
+export interface InputProps extends GlassProps, React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  const {
+    className,
+    style,
+    padding = '8px 12px',
+    displacementScale,
+    blurAmount,
+    saturation,
+    aberrationIntensity,
+    elasticity,
+    cornerRadius,
+    overLight,
+    mode,
+    mouseContainer,
+    ...inputProps
+  } = props
+
+  return (
+    <LiquidGlass
+      displacementScale={displacementScale}
+      blurAmount={blurAmount}
+      saturation={saturation}
+      aberrationIntensity={aberrationIntensity}
+      elasticity={elasticity}
+      cornerRadius={cornerRadius}
+      overLight={overLight}
+      mode={mode}
+      mouseContainer={mouseContainer}
+      padding={padding}
+      className={cn('inline-block', className)}
+      style={style}
+    >
+      <input ref={ref} className="bg-transparent outline-none border-none w-full" {...inputProps} />
+    </LiquidGlass>
+  )
+})
+
+Input.displayName = 'Input'
+

--- a/glass-ui/src/components/Modal.tsx
+++ b/glass-ui/src/components/Modal.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import LiquidGlass from 'liquid-glass-react'
+import { GlassProps } from '../types'
+import { cn } from '../utils'
+
+/**
+ * Modal component using liquid glass for the dialog container.
+ */
+export interface ModalProps extends GlassProps, React.HTMLAttributes<HTMLDivElement> {
+  /** Controls whether the modal is visible */
+  open: boolean
+  /** Called when the backdrop is clicked */
+  onClose?: () => void
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  open,
+  onClose,
+  children,
+  className,
+  style,
+  padding = '24px 32px',
+  displacementScale,
+  blurAmount,
+  saturation,
+  aberrationIntensity,
+  elasticity,
+  cornerRadius,
+  overLight,
+  mode,
+  mouseContainer,
+  ...rest
+}) => {
+  if (!open) return null
+
+  const { onClick, ...divProps } = rest
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <LiquidGlass
+        displacementScale={displacementScale}
+        blurAmount={blurAmount}
+        saturation={saturation}
+        aberrationIntensity={aberrationIntensity}
+        elasticity={elasticity}
+        cornerRadius={cornerRadius}
+        overLight={overLight}
+        mode={mode}
+        mouseContainer={mouseContainer}
+        padding={padding}
+        className={cn('relative max-w-lg w-full', className)}
+        style={style}
+        {...divProps}
+      >
+        {children}
+      </LiquidGlass>
+    </div>
+  )
+}
+

--- a/glass-ui/src/index.ts
+++ b/glass-ui/src/index.ts
@@ -1,0 +1,6 @@
+export * from './components/Button'
+export * from './components/Card'
+export * from './components/Input'
+export * from './components/Modal'
+export type { GlassProps } from './types'
+export * from './utils'

--- a/glass-ui/src/types.d.ts
+++ b/glass-ui/src/types.d.ts
@@ -1,0 +1,32 @@
+import React from 'react'
+
+/**
+ * Shared glass component props derived from `liquid-glass-react`.
+ */
+export interface GlassProps {
+  /** Displacement effect intensity */
+  displacementScale?: number
+  /** Amount of blur applied */
+  blurAmount?: number
+  /** Color saturation */
+  saturation?: number
+  /** Chromatic aberration intensity */
+  aberrationIntensity?: number
+  /** Elasticity of the glass */
+  elasticity?: number
+  /** Border radius */
+  cornerRadius?: number
+  /** Whether placed over light background */
+  overLight?: boolean
+  /** Refraction mode */
+  mode?: 'standard' | 'polar' | 'prominent' | 'shader'
+  /** Container for tracking mouse movement */
+  mouseContainer?: React.RefObject<HTMLElement | null> | null
+  /** Padding for the glass container */
+  padding?: string
+  /** Additional style */
+  style?: React.CSSProperties
+  /** Additional class names */
+  className?: string
+}
+

--- a/glass-ui/src/utils.ts
+++ b/glass-ui/src/utils.ts
@@ -1,0 +1,4 @@
+/** Merge class names conditionally */
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}

--- a/glass-ui/tsconfig.json
+++ b/glass-ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "ES2019",
+    "module": "ESNext",
+    "baseUrl": ".",
+    "paths": {"liquid-glass-react": ["../src"]},
+    "jsx": "react-jsx",
+    "declaration": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create `@glass/ui` React component package
- use `liquid-glass-react` for Button, Card, Input, and Modal components
- add shared type definitions and utility for merging class names
- include TypeScript project config and build scripts
- document installation and usage in README

## Testing
- `npx tsc -p glass-ui/tsconfig.json`
- `(cd glass-ui && npm run build)`


------
https://chatgpt.com/codex/tasks/task_e_688771d20a6c8326ba04a7e082ccc0f7